### PR TITLE
Support debug record resoponse

### DIFF
--- a/lib/yao/yrb.rb
+++ b/lib/yao/yrb.rb
@@ -16,6 +16,7 @@ module Yao
         user_domain_name     ENV['OS_USER_DOMAIN_NAME']
         project_domain_name  ENV['OS_PROJECT_DOMAIN_NAME']
         debug                ENV['YAO_DEBUG']
+        debug_record_response ENV['YAO_DEBUG_RECORD_RESPONSE']
       end
 
       IRB.setup('yao')

--- a/lib/yao/yrb.rb
+++ b/lib/yao/yrb.rb
@@ -5,17 +5,17 @@ module Yao
   module Yrb
     def self.run
       Yao.configure do
-        auth_url             ENV['OS_AUTH_URL']
-        tenant_name          ENV['OS_TENANT_NAME']
-        username             ENV['OS_USERNAME']
-        password             ENV['OS_PASSWORD']
-        client_cert          ENV['OS_CERT']
-        client_key           ENV['OS_KEY']
-        region_name          ENV['OS_REGION_NAME']
-        identity_api_version ENV['OS_IDENTITY_API_VERSION']
-        user_domain_name     ENV['OS_USER_DOMAIN_NAME']
-        project_domain_name  ENV['OS_PROJECT_DOMAIN_NAME']
-        debug                ENV['YAO_DEBUG']
+        auth_url              ENV['OS_AUTH_URL']
+        tenant_name           ENV['OS_TENANT_NAME']
+        username              ENV['OS_USERNAME']
+        password              ENV['OS_PASSWORD']
+        client_cert           ENV['OS_CERT']
+        client_key            ENV['OS_KEY']
+        region_name           ENV['OS_REGION_NAME']
+        identity_api_version  ENV['OS_IDENTITY_API_VERSION']
+        user_domain_name      ENV['OS_USER_DOMAIN_NAME']
+        project_domain_name   ENV['OS_PROJECT_DOMAIN_NAME']
+        debug                 ENV['YAO_DEBUG']
         debug_record_response ENV['YAO_DEBUG_RECORD_RESPONSE']
       end
 


### PR DESCRIPTION
Hi @buty4649 san

I want to enable `Yao.config.debug_record_response` to `true`,  but yrb does not have configuration interface . 

This PR add below code 

```ruby 
        debug_record_response ENV['YAO_DEBUG_RECORD_RESPONSE']
```

----

## 一行で

`Yao.config.debug_record_response` を設定できるようにしたい! 