### PR TITLE
save command histories in ~/.yrb_history

### DIFF
--- a/lib/yao/yrb.rb
+++ b/lib/yao/yrb.rb
@@ -1,5 +1,7 @@
 require 'irb'
 require 'irb/completion'
+require 'irb/ext/save-history'
+
 require 'yao'
 
 module Yao
@@ -28,7 +30,9 @@ module Yao
         :PROMPT_C => 'yao(%m):%03n:%i* ',
           :RETURN => "=> %s\n",
       }}
-      IRB.conf[:PROMPT_MODE] = :YAO
+      IRB.conf[:PROMPT_MODE]  = :YAO
+      IRB.conf[:SAVE_HISTORY] = 1000
+      IRB.conf[:HISTORY_FILE] = File.expand_path('~/.yrb_history')
       IRB::Irb.new.run(IRB.conf)
     end
   end


### PR DESCRIPTION
`irb` can save histories by using `'irb/ext/save-history'`  and very useful !

ref https://qiita.com/ota42y/items/ca22bc6ddf745a858444

## ~/.yrb_history ?

`~/.yrb_history` will contains `yrb` command histrories like following.

```
$ tail ~/.yrb_history
Yao::Resources::FloatingIP.list.first.tenant
Yao::Resources::FloatingIP.list.first.project_id
Yao::Tenant.get(project_id)
```

---

## 日本語でおk

デフォルトで履歴残せるようにできるらしくて便利だよ