### PR TITLE
Use pry instead of irb

### DIFF
--- a/lib/yao/yrb/cli.rb
+++ b/lib/yao/yrb/cli.rb
@@ -1,8 +1,6 @@
-require 'irb'
-require 'irb/completion'
-require 'irb/ext/save-history'
 require 'clamp'
 require 'yao'
+require 'pry'
 
 # [HACK] allow optional and multivalued parameters
 original_verbosity = $VERBOSE
@@ -40,18 +38,9 @@ module Yao::Yrb
         script_file = script_mode.first
         load script_file
       else
-        IRB.setup('yao')
-        IRB.conf[:PROMPT] = { :YAO => {
-          :PROMPT_I => 'yao(%m):%03n:%i> ',
-          :PROMPT_N => 'yao(%m):%03n:%i> ',
-          :PROMPT_S => 'yao(%m):%03n:%i%l ',
-          :PROMPT_C => 'yao(%m):%03n:%i* ',
-            :RETURN => "=> %s\n",
-        }}
-        IRB.conf[:PROMPT_MODE]  = :YAO
-        IRB.conf[:SAVE_HISTORY] = 1000
-        IRB.conf[:HISTORY_FILE] = File.expand_path('~/.yrb_history')
-        IRB::Irb.new.run(IRB.conf)
+        opts = Pry::CLI.parse_options([])
+        Pry.config.prompt_name = "yao"
+        Pry::CLI.start(opts)
       end
 
     end

--- a/yao-yrb.gemspec
+++ b/yao-yrb.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'yao'
   spec.add_dependency 'clamp', '~> 1.3.1'
+  spec.add_dependency 'pry'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
irbの代わりに[pry](https://github.com/pry/pry)を使うようにする。
pryにすることでシンタクスハイライトが効いて出力が見やすくなったり、ページャーがついたりするのでとても便利になる。